### PR TITLE
add Travis configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit=
+	setup.py
+	runtests.py
+	makemigrations.py
+	*/tests/*

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root=true
+
+[tox.ini]
+indent_style=space
+indent_size=4

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root=true
 [tox.ini]
 indent_style=space
 indent_size=4
+
+[*.yml]
+indent_style=space
+indent_size=2

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ venv/**
 dist/**
 django_automationcommon.egg-info/**
 
+# Tox output
+.coverage
+.tox/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO_VER=2.0
+    - python: "3.6"
+      env: DJANGO_VER=1.8
 
 install:
   - pip install tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# The various combinations of python and Django we test with
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+env:
+  - DJANGO_VER=1.8
+  - DJANGO_VER=1.11
+  - DJANGO_VER=2.0
+matrix:
+  exclude:
+    - python: "2.7"
+      env: DJANGO_VER=2.0
+
+install:
+  - pip install tox codecov
+# Test with "system" python and specified Django version
+script:
+  - tox -e py-django${DJANGO_VER}
+after_success:
+  - codecov
+

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,13 @@
 Automation Common
 =================
 
+.. image:: https://travis-ci.org/uisautomation/django-automationcommon.svg?branch=master
+    :target: https://travis-ci.org/uisautomation/django-automationcommon
+
+.. image:: https://codecov.io/gh/uisautomation/django-automationcommon/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/uisautomation/django-automationcommon
+
+
 Automation Common is a simple Django app that provides common functionality across different Django projects of the UofC UIS Automation team.
 
 Quick start

--- a/automationcommon/models.py
+++ b/automationcommon/models.py
@@ -13,7 +13,7 @@ LOGGER = logging.getLogger('automationcommon')
 
 
 LOCAL_USER_WARNING = """
-    Use automationcommon.models.set_local_user() to set the user to be used in the audit trail or 
+    Use automationcommon.models.set_local_user() to set the user to be used in the audit trail or
     automationcommon.middleware.RequestUserMiddleware if you are in the context of a webapp.
 """
 
@@ -141,7 +141,7 @@ class ModelChangeMixin(object):
             for diff in self.diffs:
                 if request_user:
                     # Workaround for is_anonymous becoming an attribute in Django >=1.10.
-                    is_anon = request_user.user.is_anonymous() if callable(request_user.is_anonymous) else request_user.is_anonymous
+                    is_anon = request_user.is_anonymous() if callable(request_user.is_anonymous) else request_user.is_anonymous
                     Audit.objects.create(
                         who=None if is_anon else request_user,
                         model=self.__class__.__name__,
@@ -164,7 +164,7 @@ class ModelChangeMixin(object):
         request_user = get_local_user()
         if request_user:
             # Workaround for is_anonymous becoming an attribute in Django >=1.10.
-            is_anon = request_user.user.is_anonymous() if callable(request_user.is_anonymous) else request_user.is_anonymous
+            is_anon = request_user.is_anonymous() if callable(request_user.is_anonymous) else request_user.is_anonymous
             for field, value in self.__initial.items():
                 if field != 'id' and value:
                     Audit.objects.create(

--- a/automationcommon/tests/test_models.py
+++ b/automationcommon/tests/test_models.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import mock
 
 from django.contrib.auth.models import User, AnonymousUser
 from testfixtures import LogCapture
@@ -36,7 +37,9 @@ class ModelsTests(UnitTestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.user = User.objects.create(username="it123")
+        with mock.patch('ucamlookup.utils.PersonMethods') as mocked_pm:
+            mocked_pm.return_value.getPerson.return_value = None
+            cls.user = User.objects.create(username="it123")
 
     def setUp(self):
         set_local_user(self.user)

--- a/automationcommon/utils.py
+++ b/automationcommon/utils.py
@@ -176,13 +176,14 @@ def send(recipients, email_template, context, attachments=None, reply_to=None, b
     if bcc:
         kwargs['bcc'] = [settings.SERVER_EMAIL]
 
-    final_kwargs = {**{
+    final_kwargs = {
         'subject': subject_and_body[0],
         'body': subject_and_body[1],
         'from_email': settings.SERVER_EMAIL_FULL,
         'to': to,
         'headers': {'Return-Path': settings.SERVER_EMAIL}
-    }, **kwargs}
+    }
+    final_kwargs.update(kwargs)
 
     message = EmailMultiAlternatives(**final_kwargs)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist=py27-django{1.8,1.11},{py,py3}-django{1.8,1.11,2.0}
+
+[testenv]
+basepython=
+    py: python
+    py27: python2.7
+    py3: python3
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+deps=
+    coverage
+    testfixtures
+    django1.8: Django>=1.8,<1.9
+    django1.11: Django>=1.11,<1.12
+    django2.0: Django>=2.0,<2.1
+commands=
+    python --version
+    coverage run --source={toxinidir} --omit={toxworkdir}/* ./runtests.py {posargs}
+    coverage html --directory {toxinidir}/build/htmlcov/
+    coverage report


### PR DESCRIPTION
This PR adds a Travis configuration to run tests in Djangos 1.8, 1.11 and 2.0 with Pythons 2.7, 3.4, 3.5 and 3.6.

The combination of Django 2.0 and Python 2.7 is excluded since Django 2.0 no longer supports Python 2.7

Commits 3877696 and 0ecaba9 provide fixes for issues with earlier Djangos and Pythons which were found when writing this PR. Commit 9bc63f6 provides a missing mock for the Lookup API which is unavailable outside the CUDN. The remaining test suite was tested with no network connection to make sure there aren't any other unexpected calls to network services.