### PR TITLE
Better audit of delete

### DIFF
--- a/automationcommon/models.py
+++ b/automationcommon/models.py
@@ -166,7 +166,7 @@ class ModelChangeMixin(object):
             # Workaround for is_anonymous becoming an attribute in Django >=1.10.
             is_anon = request_user.is_anonymous() if callable(request_user.is_anonymous) else request_user.is_anonymous
             for field, value in self.__initial.items():
-                if field != 'id' and value:
+                if value:
                     Audit.objects.create(
                         who=None if is_anon else request_user,
                         model=self.__class__.__name__,

--- a/automationcommon/tests/test_models.py
+++ b/automationcommon/tests/test_models.py
@@ -23,6 +23,7 @@ class TestModel(ModelChangeMixin, FakeModel):
 
     def __init__(self, *args, **kwargs):
         self.fields = {
+            'id': 1,
             'name': 'the round window',
             'description': "it's round",
         }
@@ -100,6 +101,7 @@ class ModelsTests(UnitTestCase):
 
         # test
         self.test_model.fields = {
+            'id': 1,
             'name': 'the square window',
             'description': "no wait, it's actually square!",
         }
@@ -121,14 +123,17 @@ class ModelsTests(UnitTestCase):
         self.test_model.delete()
 
         # check
-        self.assertEqual(2, Audit.objects.count())
+        self.assertEqual(3, Audit.objects.count())
         audits = Audit.objects.all().order_by('field')
         self.assertEqual('description', audits[0].field)
         self.assertEqual("it's round", audits[0].old)
         self.assertIsNone(audits[0].new)
-        self.assertEqual('name', audits[1].field)
-        self.assertEqual("the round window", audits[1].old)
+        self.assertEqual('id', audits[1].field)
+        self.assertEqual("1", audits[1].old)
         self.assertIsNone(audits[1].new)
+        self.assertEqual('name', audits[2].field)
+        self.assertEqual("the round window", audits[2].old)
+        self.assertIsNone(audits[2].new)
 
     def tearDown(self):
         clear_local_user()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 setup(
     name='django-automationcommon',
     # When changing this version number, remember to update CHANGELOG.
-    version='1.16',
+    version='1.17',
     packages=find_packages(),
     include_package_data=True,
     license='MIT',


### PR DESCRIPTION
When deleting - an audit record for a model's 'id' field is now also created. Otherwise there would be no record of a model with all None values being deleted.