### PR TITLE
add support for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,17 @@ env:
   - DJANGO_VER=1.8
   - DJANGO_VER=1.11
   - DJANGO_VER=2.0
+  - DJANGO_VER=2.1
 matrix:
   exclude:
     - python: "2.7"
       env: DJANGO_VER=2.0
+    - python: "2.7"
+      env: DJANGO_VER=2.1
     - python: "3.6"
       env: DJANGO_VER=1.8
+    - python: "3.4"
+      env: DJANGO_VER=2.1
 
 install:
   - pip install tox codecov

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email='automation@uis.cam.ac.uk',
     tests_require=['testfixtures'],
     install_requires=[
-        'django>=1.8,<2.1',
+        'django>=1.8,<2.2',
         'django-ucamlookup>=1.9.2',
         'django-ucamwebauth>=1.4.5',
         'requests',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-django{1.8,1.11},{py,py3}-django{1.8,1.11,2.0}
+envlist=py27-django{1.8,1.11},{py,py3}-django{1.8,1.11,2.0,2.1}
 
 [testenv]
 basepython=
@@ -15,6 +15,7 @@ deps=
     django1.8: Django>=1.8,<1.9
     django1.11: Django>=1.11,<1.12
     django2.0: Django>=2.0,<2.1
+    django2.1: Django>=2.1,<2.2
 commands=
     python --version
     coverage run --source={toxinidir} --omit={toxworkdir}/* ./runtests.py {posargs}


### PR DESCRIPTION
No code changes but update setup.py to allow Django 2.1 and add django 2.1 to the travis configuration. Do not add Python 3.7 for the moment until Travis' 3.7 support is more mature.